### PR TITLE
FW 294/more props

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 // Package version
-version = "0.2.1"
+version = "0.3.0"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayload.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayload.kt
@@ -10,8 +10,19 @@ import org.apache.kafka.connect.errors.DataException
 import org.apache.kafka.connect.transforms.Transformation
 import org.apache.kafka.connect.transforms.util.Requirements
 
+data class NTuple5<T1, T2, T3, T4, T5>(val t1: T1, val t2: T2, val t3: T3, val t4: T4, val t5: T5)
+
 class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<R> {
-    private val ignoredAttributes = arrayListOf("account_aggregate_id", "oauth_response_data.access_token", "oauth_response_data.team_id", "oauth_response_data.team_name", "oauth_response_data.bot.bot_access_token", "oauth_response_data.team.id", "oauth_response_data.team.name")
+    private val ignoredAttributes = arrayListOf(
+            "account_aggregate_id",
+            "oauth_response_data.access_token",
+            "oauth_response_data.team_id",
+            "oauth_response_data.team_name",
+            "oauth_response_data.scope",
+            "oauth_response_data.bot.bot_access_token",
+            "oauth_response_data.team.id",
+            "oauth_response_data.team.name"
+    )
     private val PURPOSE = "unify legacy slack integration data"
     override fun configure(configs: MutableMap<String, *>?) {}
 
@@ -53,10 +64,12 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
         return updatedValues
     }
 
-    private fun extractUnifiedValues(oauthResponseData: Struct): Triple<String, String, String> {
+    private fun extractUnifiedValues(oauthResponseData: Struct): NTuple5<String, String, String, String, String?> {
         var teamId: String
         var teamName: String
         var accessToken: String
+        var scope: String
+        var enterpriseId: String? = null
 
         try {
             // Only Slack Integration OAuth V1 has "bot" child element
@@ -64,21 +77,23 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
             teamId = oauthResponseData.get("team_id") as String
             teamName = oauthResponseData.get("team_name") as String
             accessToken = dot.get("bot_access_token") as String
+            scope = oauthResponseData.get("scope") as String
         } catch (e: DataException) {
             // Slack Integration OAuth V2 Payload
             val team: Struct = Requirements.requireStruct(oauthResponseData.get("team"), oauthResponseData.toString())
             teamId = team.get("id") as String
             teamName = team.get("name") as String
             accessToken = oauthResponseData.get("access_token") as String
+            scope = oauthResponseData.get("scope") as String
         }
-        return Triple(teamId, teamName, accessToken)
+        return NTuple5(teamId, teamName, accessToken, scope, enterpriseId)
     }
 
     override fun apply(record: R): R {
         val valueStruct: Struct = Requirements.requireStruct(record.value(), PURPOSE)
         val oauthResponseData: Struct = Requirements.requireStruct(valueStruct.get("oauth_response_data"), PURPOSE)
         val updatedSchemaBuilder: SchemaBuilder = removeIgnoredAttributes(valueStruct.schema().fields(), SchemaBuilder.struct())
-        val(teamId, teamName, accessToken) = extractUnifiedValues(oauthResponseData)
+        val(teamId, teamName, accessToken, scope, _) = extractUnifiedValues(oauthResponseData)
 
         // Add back the unified fields
         val modifiedPayloadSchema = updatedSchemaBuilder
@@ -87,6 +102,7 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
             .field("access_token", Schema.STRING_SCHEMA)
             .field("team_id", Schema.STRING_SCHEMA)
             .field("team_name", Schema.STRING_SCHEMA)
+            .field("scope", Schema.STRING_SCHEMA)
             .build()
 
         val updatedValuesStruct: Struct = populateValue(valueStruct, Struct(modifiedPayloadSchema))
@@ -95,6 +111,7 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
             .put("access_token", accessToken)
             .put("team_id", teamId)
             .put("team_name", teamName)
+            .put("scope", scope)
 
         return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), modifiedPayloadSchema, modifiedPayloadStruct, record.timestamp())
     }

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayload.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayload.kt
@@ -114,7 +114,7 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
             .field("access_token", Schema.STRING_SCHEMA)
             .field("team_id", Schema.STRING_SCHEMA)
             .field("team_name", Schema.STRING_SCHEMA)
-            .field("scope", Schema.STRING_SCHEMA)
+            .field("access_token_scopes", Schema.STRING_SCHEMA)
             .field("enterprise_id", Schema.OPTIONAL_STRING_SCHEMA)
             .build()
 
@@ -124,7 +124,7 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
             .put("access_token", accessToken)
             .put("team_id", teamId)
             .put("team_name", teamName)
-            .put("scope", scope)
+            .put("access_token_scopes", scope)
             .put("enterprise_id", enterpriseId)
 
         return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), modifiedPayloadSchema, modifiedPayloadStruct, record.timestamp())

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayload.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayload.kt
@@ -22,7 +22,8 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
             "oauth_response_data.scope",
             "oauth_response_data.bot.bot_access_token",
             "oauth_response_data.team.id",
-            "oauth_response_data.team.name"
+            "oauth_response_data.team.name",
+            "oauth_response_data.enterprise.id",
     )
     private val PURPOSE = "unify legacy slack integration data"
     override fun configure(configs: MutableMap<String, *>?) {}
@@ -74,10 +75,10 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
 
         try {
             // Only Slack Integration OAuth V1 has "bot" child element
-            val dot: Struct = Requirements.requireStruct(oauthResponseData.get("bot"), PURPOSE)
+            val bot: Struct = Requirements.requireStruct(oauthResponseData.get("bot"), PURPOSE)
             teamId = oauthResponseData.get("team_id") as String
             teamName = oauthResponseData.get("team_name") as String
-            accessToken = dot.get("bot_access_token") as String
+            accessToken = bot.get("bot_access_token") as String
             scope = oauthResponseData.get("scope") as String
             enterpriseId = oauthResponseData.get("enterprise_id") as String?
         } catch (e: DataException) {
@@ -87,6 +88,11 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
             teamName = team.get("name") as String
             accessToken = oauthResponseData.get("access_token") as String
             scope = oauthResponseData.get("scope") as String
+            // TODO: Figure out how to check if the struct is there in a safe way.
+            // var enterprise: Struct? = oauthResponseData.get("enterprise") as Struct?
+            // if (enterprise != null) {
+            //     enterpriseId = enterprise.get("id") as String?
+            // }
         }
         return Quintuple(teamId, teamName, accessToken, scope, enterpriseId)
     }

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayload.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayload.kt
@@ -14,16 +14,16 @@ data class Quintuple<T1, T2, T3, T4, T5>(val t1: T1, val t2: T2, val t3: T3, val
 
 class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<R> {
     private val ignoredAttributes = arrayListOf(
-            "account_aggregate_id",
-            "oauth_response_data.access_token",
-            "oauth_response_data.team_id",
-            "oauth_response_data.team_name",
-            "oauth_response_data.enterprise_id",
-            "oauth_response_data.scope",
-            "oauth_response_data.bot.bot_access_token",
-            "oauth_response_data.team.id",
-            "oauth_response_data.team.name",
-            "oauth_response_data.enterprise.id",
+        "account_aggregate_id",
+        "oauth_response_data.access_token",
+        "oauth_response_data.team_id",
+        "oauth_response_data.team_name",
+        "oauth_response_data.enterprise_id",
+        "oauth_response_data.scope",
+        "oauth_response_data.bot.bot_access_token",
+        "oauth_response_data.team.id",
+        "oauth_response_data.team.name",
+        "oauth_response_data.enterprise.id",
     )
     private val PURPOSE = "unify legacy slack integration data"
     override fun configure(configs: MutableMap<String, *>?) {}
@@ -88,13 +88,17 @@ class UnifyLegacySlackIntegrationPayload<R : ConnectRecord<R>> : Transformation<
             teamName = team.get("name") as String
             accessToken = oauthResponseData.get("access_token") as String
             scope = oauthResponseData.get("scope") as String
-            // TODO: Figure out how to check if the struct is there in a safe way.
-            // var enterprise: Struct? = oauthResponseData.get("enterprise") as Struct?
-            // if (enterprise != null) {
-            //     enterpriseId = enterprise.get("id") as String?
-            // }
+            enterpriseId = extractEnterpriseValue(oauthResponseData)
         }
         return Quintuple(teamId, teamName, accessToken, scope, enterpriseId)
+    }
+
+    private fun extractEnterpriseValue(oauthResponseData: Struct): String? {
+        try {
+            return Requirements.requireStruct(oauthResponseData.get("enterprise"), PURPOSE).get("id") as String
+        } catch (e: DataException) {
+            return null
+        }
     }
 
     override fun apply(record: R): R {

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayloadTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayloadTest.kt
@@ -67,10 +67,18 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .put("id", TEAM_ID)
             .put("name", TEAM_NAME)
 
+        val enterpriseSchema = SchemaBuilder.struct()
+            .field("id", Schema.STRING_SCHEMA)
+            .build()
+
+        val enterpriseStruct = Struct(teamSchema)
+            .put("id", ENTERPRISE_ID)
+
         val oauthResponseDataSchema = SchemaBuilder.struct()
             .field("access_token", Schema.STRING_SCHEMA)
             .field("scope", Schema.STRING_SCHEMA)
             .field("team", teamSchema)
+            // .field("enterprise", null)
             .build()
 
         val oauthResponseDataStruct = Struct(oauthResponseDataSchema)
@@ -182,7 +190,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .put("team_id", TEAM_ID)
             .put("team_name", TEAM_NAME)
             .put("scope", SCOPE)
-            // .put("enterprise_id", null)
+            .put("enterprise_id", null)
 
         assertEquals(expectedValue, transformedRecord.value())
         assertEquals(expectedSchema, transformedRecord.valueSchema())

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayloadTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayloadTest.kt
@@ -13,7 +13,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
     private val ACCOUNT_ID = "account-id"
     private val TEAM_ID = "team-id"
     private val TEAM_NAME = "team-name"
-    private val SCOPE = "scope"
+    private val SCOPE = "access_token_scopes"
     private val ENTERPRISE_ID = "enterprise-id"
 
     private fun createOAuthV1Payload(enterpriseId: String?): Pair<Schema, Struct> {
@@ -134,7 +134,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .field("access_token", Schema.STRING_SCHEMA)
             .field("team_id", Schema.STRING_SCHEMA)
             .field("team_name", Schema.STRING_SCHEMA)
-            .field("scope", Schema.STRING_SCHEMA)
+            .field("access_token_scopes", Schema.STRING_SCHEMA)
             .field("enterprise_id", Schema.OPTIONAL_STRING_SCHEMA)
             .build()
 
@@ -145,7 +145,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .put("access_token", ACCESS_TOKEN)
             .put("team_id", TEAM_ID)
             .put("team_name", TEAM_NAME)
-            .put("scope", SCOPE)
+            .put("access_token_scopes", SCOPE)
             .put("enterprise_id", enterpriseId)
 
         return expectedSchema to expectedValue
@@ -191,7 +191,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .field("access_token", Schema.STRING_SCHEMA)
             .field("team_id", Schema.STRING_SCHEMA)
             .field("team_name", Schema.STRING_SCHEMA)
-            .field("scope", Schema.STRING_SCHEMA)
+            .field("access_token_scopes", Schema.STRING_SCHEMA)
             .field("enterprise_id", Schema.OPTIONAL_STRING_SCHEMA)
             .build()
         val expectedValue = Struct(expectedSchema)
@@ -199,7 +199,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .put("access_token", ACCESS_TOKEN)
             .put("team_id", TEAM_ID)
             .put("team_name", TEAM_NAME)
-            .put("scope", SCOPE)
+            .put("access_token_scopes", SCOPE)
             .put("enterprise_id", null)
 
         assertEquals(expectedValue, transformedRecord.value())
@@ -220,7 +220,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .field("access_token", Schema.STRING_SCHEMA)
             .field("team_id", Schema.STRING_SCHEMA)
             .field("team_name", Schema.STRING_SCHEMA)
-            .field("scope", Schema.STRING_SCHEMA)
+            .field("access_token_scopes", Schema.STRING_SCHEMA)
             .field("enterprise_id", Schema.OPTIONAL_STRING_SCHEMA)
             .build()
         val expectedValue = Struct(expectedSchema)
@@ -228,7 +228,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .put("access_token", ACCESS_TOKEN)
             .put("team_id", TEAM_ID)
             .put("team_name", TEAM_NAME)
-            .put("scope", SCOPE)
+            .put("access_token_scopes", SCOPE)
             .put("enterprise_id", ENTERPRISE_ID)
 
         assertEquals(expectedValue, transformedRecord.value())

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayloadTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnifyLegacySlackIntegrationPayloadTest.kt
@@ -13,6 +13,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
     private val ACCOUNT_ID = "account-id"
     private val TEAM_ID = "team-id"
     private val TEAM_NAME = "team-name"
+    private val SCOPE = "scope"
 
     private fun createOAuthV1Payload(): Pair<Schema, Struct> {
         val botSchema = SchemaBuilder.struct()
@@ -28,6 +29,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .field("access_token", Schema.STRING_SCHEMA)
             .field("team_id", Schema.STRING_SCHEMA)
             .field("team_name", Schema.STRING_SCHEMA)
+            .field("scope", Schema.STRING_SCHEMA)
             .field("bot", botSchema)
             .build()
 
@@ -35,6 +37,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .put("access_token", "a-b-c")
             .put("team_id", TEAM_ID)
             .put("team_name", TEAM_NAME)
+            .put("scope", SCOPE)
             .put("bot", botStruct)
 
         val payloadSchema = SchemaBuilder.struct()
@@ -63,11 +66,13 @@ class UnifyLegacySlackIntegrationPayloadTest {
 
         val oauthResponseDataSchema = SchemaBuilder.struct()
             .field("access_token", Schema.STRING_SCHEMA)
+            .field("scope", Schema.STRING_SCHEMA)
             .field("team", teamSchema)
             .build()
 
         val oauthResponseDataStruct = Struct(oauthResponseDataSchema)
             .put("access_token", ACCESS_TOKEN)
+            .put("scope", SCOPE)
             .put("team", teamStruct)
 
         val payloadSchema = SchemaBuilder.struct()
@@ -105,6 +110,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .field("access_token", Schema.STRING_SCHEMA)
             .field("team_id", Schema.STRING_SCHEMA)
             .field("team_name", Schema.STRING_SCHEMA)
+            .field("scope", Schema.STRING_SCHEMA)
             .build()
 
         val expectedValue = Struct(expectedSchema)
@@ -114,6 +120,7 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .put("access_token", ACCESS_TOKEN)
             .put("team_id", TEAM_ID)
             .put("team_name", TEAM_NAME)
+            .put("scope", SCOPE)
 
         return expectedSchema to expectedValue
     }
@@ -145,12 +152,14 @@ class UnifyLegacySlackIntegrationPayloadTest {
             .field("access_token", Schema.STRING_SCHEMA)
             .field("team_id", Schema.STRING_SCHEMA)
             .field("team_name", Schema.STRING_SCHEMA)
+            .field("scope", Schema.STRING_SCHEMA)
             .build()
         val expectedValue = Struct(expectedSchema)
             .put("account_aggregate_id", ACCOUNT_ID)
             .put("access_token", ACCESS_TOKEN)
             .put("team_id", TEAM_ID)
             .put("team_name", TEAM_NAME)
+            .put("scope", SCOPE)
 
         assertEquals(expectedValue, transformedRecord.value())
         assertEquals(expectedSchema, transformedRecord.valueSchema())


### PR DESCRIPTION
Flow requires additional params that are exported from the SlackIntegration data. This PR adds them to the exported schema.

- add scope to the schema that is returned.
- Working enterprise id for v1 tokens.
- Working enterprise id for v2 tokens.