### PR TITLE
Redshift flatten + transform complex types to json strings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 // Package version
-version = "0.7.0-alpha"
+version = "0.7.0"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 // Package version
-version = "0.6.1-alpha"
+version = "0.7.0-alpha"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 // Package version
-version = "0.6.0"
+version = "0.6.1-alpha"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
@@ -5,7 +5,6 @@ import org.apache.kafka.common.cache.LRUCache
 import org.apache.kafka.common.cache.SynchronizedCache
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.ConnectRecord
-import org.apache.kafka.connect.data.Field
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct
@@ -62,13 +61,6 @@ class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<
             value,
             record.timestamp()
         )
-    }
-
-    private fun updateSchema(field: Field): Schema {
-        if (field.schema().type() == Schema.Type.ARRAY || field.schema().type() == Schema.Type.MAP) {
-            return SchemaBuilder.string().build()
-        }
-        return field.schema()
     }
 
     private fun fieldName(prefix: String, fieldName: String): String {
@@ -182,26 +174,6 @@ class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<
             buildWithSchema(sourceValue, "", updatedValue)
             return newRecord(record, updatedSchema, updatedValue)
         }
-
-        /*val builder = SchemaUtil.copySchemaBasics(sourceSchema, SchemaBuilder.struct())
-        for (field in sourceSchema.fields()) {
-            builder.field(field.name(), updateSchema(field))
-        }
-        val newSchema = builder.build()
-        val targetPayload = Struct(newSchema)
-        for (field in newSchema.fields()) {
-            val fieldVal = sourceValue.get(field.name())
-            val fieldSchema = sourceSchema.field(field.name()).schema()
-            if (field.schema().type() == fieldSchema.type()) {
-                targetPayload.put(field.name(), fieldVal)
-            } else {
-                //val converted = jsonConverter.fromConnectData("", fieldSchema, fieldVal)
-                //var fieldString = objectMapper.readTree(converted).toString()
-                val fieldString = convertToString(fieldSchema, fieldVal)
-                targetPayload.put(field.name(), fieldString)
-            }
-        }
-        return newRecord(record, targetPayload.schema(), targetPayload)*/
     }
 
     private val objectMapper = ObjectMapper()

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
@@ -115,8 +115,18 @@ class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<
         }
     }
 
-    private fun convertToString(schema: Schema, value: Any): String {
-        val converted = jsonConverter.fromConnectData("", schema, value)
+    private fun convertToString(schema: Schema, value: Any?): String {
+        var realValue = value
+        var realSchema = schema
+        if (value == null && schema.type() == Schema.Type.ARRAY) {
+            realValue = "[]"
+            realSchema = SchemaBuilder.string().build()
+        }
+        if (value == null && schema.type() == Schema.Type.MAP) {
+            realValue = "{}"
+            realSchema = SchemaBuilder.string().build()
+        }
+        val converted = jsonConverter.fromConnectData("", realSchema, realValue)
         var fieldString = objectMapper.readTree(converted).toString()
         return fieldString.replace("\"[", "[").replace("]\"", "]").replace("\"{", "{").replace("}\"", "}")
     }

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
@@ -24,7 +24,7 @@ import java.util.Collections
  * See https://docs.confluent.io/platform/current/connect/javadocs/javadoc/org/apache/kafka/connect/transforms/Transformation.html.
  *
  * @param R is ConnectRecord<R>.
- * @constructor Creates a RedShiftArrayTransformer Transformation<R> for a given ConnectRecord<T>
+ * @constructor Creates a RedShiftComplexDataTypeTransformer Transformation<R> for a given ConnectRecord<T>
  */
 class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<R> {
     private val logger = LoggerFactory.getLogger(this::class.java.canonicalName)

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
@@ -26,7 +26,7 @@ import java.util.Collections
  * @param R is ConnectRecord<R>.
  * @constructor Creates a RedShiftArrayTransformer Transformation<R> for a given ConnectRecord<T>
  */
-class RedShiftArrayTransformer<R : ConnectRecord<R>> : Transformation<R> {
+class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<R> {
     private val logger = LoggerFactory.getLogger(this::class.java.canonicalName)
     private val purpose = "RedShift™ JSON Array to String Transform"
 
@@ -60,7 +60,7 @@ class RedShiftArrayTransformer<R : ConnectRecord<R>> : Transformation<R> {
     }
 
     private fun updateSchema(field: Field): Schema {
-        if (field.schema().type() == Schema.Type.ARRAY) {
+        if (field.schema().type() == Schema.Type.ARRAY || field.schema().type() == Schema.Type.MAP) {
             return SchemaBuilder.string().build()
         }
         return field.schema()

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
@@ -26,27 +26,27 @@ import kotlin.test.assertTrue
  * See https://docs.confluent.io/platform/current/connect/javadocs/javadoc/org/apache/kafka/connect/transforms/Transformation.html.
  *
  * @param R is ConnectRecord<R>.
- * @constructor Creates a RedShiftArrayTransformer Transformation<R> for a given ConnectRecord<T>
+ * @constructor Creates a RedShiftComplexDataTypeTransformer Transformation<R> for a given ConnectRecord<T>
  *
  */
-class RedShiftArrayTransformerTest {
+class RedShiftComplexDataTypeTransformerTest {
 
-    private lateinit var transformer: RedShiftArrayTransformer<SourceRecord>
+    private lateinit var transformer: RedShiftComplexDataTypeTransformer<SourceRecord>
 
-    private fun hasNoArrays(obj: SourceRecord): Boolean {
+    private fun hasNoComplexTypes(obj: SourceRecord): Boolean {
 
-        var hasNoArray = true
+        var hasNoComplexTypes = true
         for (field in obj.valueSchema().fields()) {
-            if (field.schema().type() == Schema.Type.ARRAY) {
-                hasNoArray = false
+            if (field.schema().type() == Schema.Type.ARRAY || field.schema().type() == Schema.Type.MAP) {
+                hasNoComplexTypes = false
             }
         }
-        return hasNoArray
+        return hasNoComplexTypes
     }
 
     @Before
     fun setUp() {
-        transformer = RedShiftArrayTransformer()
+        transformer = RedShiftComplexDataTypeTransformer()
     }
 
     @Test
@@ -62,8 +62,8 @@ class RedShiftArrayTransformerTest {
         )
 
         val transformedRecord = transformer.apply(sourceRecord)
-        hasNoArrays(sourceRecord)
-        assertTrue(hasNoArrays(transformedRecord))
+        hasNoComplexTypes(sourceRecord)
+        assertTrue(hasNoComplexTypes(transformedRecord))
     }
 
     private val sourceSchema = AvroSchema.fromJson(fileContent("com/cultureamp/employee-data.employees-value-v1.avsc"))

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
@@ -62,6 +62,7 @@ class RedShiftComplexDataTypeTransformerTest {
         )
 
         val transformedRecord = transformer.apply(sourceRecord)
+        println(transformedRecord)
         hasNoComplexTypes(sourceRecord)
         assertTrue(hasNoComplexTypes(transformedRecord))
     }

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
@@ -62,7 +62,6 @@ class RedShiftComplexDataTypeTransformerTest {
         )
 
         val transformedRecord = transformer.apply(sourceRecord)
-        println(transformedRecord)
         hasNoComplexTypes(sourceRecord)
         assertTrue(hasNoComplexTypes(transformedRecord))
     }

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
@@ -37,7 +37,7 @@ class RedShiftComplexDataTypeTransformerTest {
 
         var hasNoComplexTypes = true
         for (field in obj.valueSchema().fields()) {
-            if (field.schema().type() == Schema.Type.ARRAY || field.schema().type() == Schema.Type.MAP) {
+            if (field.schema().type() == Schema.Type.ARRAY || field.schema().type() == Schema.Type.MAP || field.schema().type() == Schema.Type.STRUCT) {
                 hasNoComplexTypes = false
             }
         }

--- a/src/test/resources/com/cultureamp/employee-data.employees-v1.json
+++ b/src/test/resources/com/cultureamp/employee-data.employees-v1.json
@@ -23,7 +23,41 @@
 		"locale": null,
 		"observer": false,
 		"gdpr_erasure_request_id": null,
-		"manager_assignment": null,
+		"manager_assignment": {
+			"manager_id": {
+				"string": "5c579970-684e-4911-a077-6bf407fb478d"
+			},
+			"demographic_id": {
+				"string": "427b936f-e932-4673-95a2-acd3e3b900b1"
+			}
+		},
+		"test_array_of_structs": [
+			{
+				"demographic_id": {
+					"string": "5c579970-684e-4911-a077-6bf407fb478d"
+				},
+				"demographic_value_id": {
+					"string": "427b936f-e932-4673-95a2-acd3e3b900b1"
+				}
+			},
+			{
+				"demographic_id": {
+					"string": "460f6b2d-03c5-46cf-ba55-aa14477a12dc"
+				},
+				"demographic_value_id": {
+					"string": "ecc0db2e-486e-4f4a-a54a-db21673e1a2b"
+				}
+			}
+		],
+		"test_map": {
+			"added_users_count": 0,
+			"ignored_new_demographics_count": 0,
+			"ignored_users_count": 0,
+			"inactive_updated_users_count": 0,
+			"reactivated_users_count": 0,
+			"removed_users_count": 0,
+			"updated_users_count": 0
+		},
 		"erased": false,
         "created_at": 1536899741113,
 		"updated_at": 1536899741117,

--- a/src/test/resources/com/cultureamp/employee-data.employees-v1.json
+++ b/src/test/resources/com/cultureamp/employee-data.employees-v1.json
@@ -57,6 +57,15 @@
 			}
 		}
 	],
+	"test_map": {
+		"added_users_count": 0,
+		"ignored_new_demographics_count": 0,
+		"ignored_users_count": 0,
+		"inactive_updated_users_count": 0,
+		"reactivated_users_count": 0,
+		"removed_users_count": 0,
+		"updated_users_count": 0
+	},
 	"test_string_array": [
 		"a", "b", "c"
 	],

--- a/src/test/resources/com/cultureamp/employee-data.employees-v1.json
+++ b/src/test/resources/com/cultureamp/employee-data.employees-v1.json
@@ -58,6 +58,7 @@
 			"removed_users_count": 0,
 			"updated_users_count": 0
 		},
+		"test_map_1": null,
 		"erased": false,
         "created_at": 1536899741113,
 		"updated_at": 1536899741117,

--- a/src/test/resources/com/cultureamp/employee-data.employees-value-v1.avsc
+++ b/src/test/resources/com/cultureamp/employee-data.employees-value-v1.avsc
@@ -265,6 +265,17 @@
         }
       ],
       "default": null
+    },
+    {
+      "name": "test_map",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "int"
+        }
+      ],
+      "default": null
     }
   ]
 }

--- a/src/test/resources/com/cultureamp/employee-data.employees-value-v1.avsc
+++ b/src/test/resources/com/cultureamp/employee-data.employees-value-v1.avsc
@@ -103,6 +103,44 @@
             "default": null
           },
           {
+            "name": "test_map",
+            "type": {
+              "type": "map",
+              "values": "string"
+            }
+          },
+          {
+            "name": "test_array_of_structs",
+            "type": {
+              "type": "array",
+              "items": {
+                "type": "record",
+                "name": "DemographicValueAssignmentTest",
+                "namespace": "com.cultureamp.employee.v1",
+                "fields": [
+                  {
+                    "name": "demographic_id",
+                    "type": {
+                      "type": "string",
+                      "logicalType": "uuid"
+                    }
+                  },
+                  {
+                    "name": "demographic_value_id",
+                    "type": [
+                      "null",
+                      {
+                        "type": "string",
+                        "logicalType": "uuid"
+                      }
+                    ],
+                    "default": null
+                  }
+                ]
+              }
+            }
+          },
+          {
             "name": "manager_assignment",
             "type": [
               "null",

--- a/src/test/resources/com/cultureamp/employee-data.employees-value-v1.avsc
+++ b/src/test/resources/com/cultureamp/employee-data.employees-value-v1.avsc
@@ -110,6 +110,17 @@
             }
           },
           {
+            "name": "test_map_1",
+            "type": [
+              "null",
+              {
+                "type": "map",
+                "values": "int"
+              }
+            ],
+            "default": null
+          },
+          {
             "name": "test_array_of_structs",
             "type": {
               "type": "array",


### PR DESCRIPTION
- JDBC Redshift connector needs to use [Flatten](https://docs.confluent.io/platform/current/connect/transforms/flatten.html) Transformer to be able to flatten nested AVRO columns into columns for Redshift tables. (Redshift is a relational data warehouse).
- The Flatten transformation can not handle nested `MAP` type AVRO columns, it fails with the error `Caused by: org.apache.kafka.connect.errors.DataException: Flatten transformation does not support MAP for record with schemas (for field body_name).`
- ECST feeds can have `MAP` columns in `body`, it is not suitable to enforce the condition on the producer teams to convert `MAP` to `record` (`STRUCT`) types as this might increase the size of the message many folds.
- This PR provides a fix in two steps:
    - Flatten `STRUCT` type columns
    - Convert `ARRAY` and `MAP` type columns into JSON formatted `STRING` so that they can be ingested into Redshift (Related: https://cultureamp.atlassian.net/browse/DASE-1196)
- https://github.com/a0x8o/kafka/blob/master/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Flatten.java was used as a reference to Flatten nested columns
- Testing:
    - Created a pre-release https://github.com/cultureamp/kafka-connect-plugins/releases/tag/v0.7.0-alpha
    - Added asset [kafka-connect-plugins-0.7.0-alpha.jar](https://github.com/cultureamp/kafka-connect-plugins/releases/download/v0.7.0-alpha/kafka-connect-plugins-0.7.0-alpha.jar) to the pre-release from https://github.com/cultureamp/kafka-connect-plugins/actions/runs/6169647428
    - Tested on `dev` connect cluster through https://github.com/cultureamp/kafka-ops/pull/858/files for about 9 topics. The previous errors about `MAP` columns are fixed.