### PR TITLE
Redshift Transformer Tombstone messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 // Package version
-version = "0.7.0"
+version = "0.7.1-alpha"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 // Package version
-version = "0.7.1-alpha"
+version = "0.7.1"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
@@ -171,8 +171,11 @@ class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<
         val props = Collections.singletonMap("schemas.enable", false)
         jsonConverter.configure(props, true)
         if (updatedSchema == null) {
-            val builder = SchemaUtil.copySchemaBasics(sourceSchema, SchemaBuilder.struct())
-            buildUpdatedSchema(sourceSchema, "", builder, sourceSchema.isOptional())
+            var builder: SchemaBuilder = SchemaUtil.copySchemaBasics(SchemaBuilder.struct())
+            if (sourceSchema != null) {
+                builder = SchemaUtil.copySchemaBasics(sourceSchema, SchemaBuilder.struct())
+                buildUpdatedSchema(sourceSchema, "", builder, sourceSchema.isOptional())
+            }
 
             if (record.keySchema() != null) {
                 builder.field("topic_key", record.keySchema())

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
@@ -66,6 +66,66 @@ class RedShiftComplexDataTypeTransformerTest {
         assertTrue(hasNoComplexTypes(transformedRecord))
     }
 
+    @Test
+    fun `can transform ECST Employee data that has key as field`() {
+
+        val avroRecord = payload("com/cultureamp/employee-data.employees-v1.json")
+        val sourceRecord = SourceRecord(
+            null,
+            null,
+            "employee data ecst test",
+            null,
+            Schema.STRING_SCHEMA,
+            "hellp",
+            avroRecord.schema(),
+            avroRecord.value()
+        )
+
+        val transformedRecord = transformer.apply(sourceRecord)
+        hasNoComplexTypes(sourceRecord)
+        assertTrue(hasNoComplexTypes(transformedRecord))
+    }
+
+    @Test
+    fun `can transform ECST Employee data with tombstone message and non-null key`() {
+
+        val avroRecord = payload("com/cultureamp/employee-data.employees-v1.json")
+        val sourceRecord = SourceRecord(
+            null,
+            null,
+            "employee data ecst test",
+            null,
+            Schema.STRING_SCHEMA,
+            "hellp",
+            avroRecord.schema(),
+            null
+        )
+
+        val transformedRecord = transformer.apply(sourceRecord)
+        hasNoComplexTypes(sourceRecord)
+        assertTrue(hasNoComplexTypes(transformedRecord))
+    }
+
+    @Test
+    fun `can transform ECST Employee data with tombstone message and null key`() {
+
+        val avroRecord = payload("com/cultureamp/employee-data.employees-v1.json")
+        val sourceRecord = SourceRecord(
+            null,
+            null,
+            "employee data ecst test",
+            null,
+            null,
+            null,
+            avroRecord.schema(),
+            null
+        )
+
+        val transformedRecord = transformer.apply(sourceRecord)
+        hasNoComplexTypes(sourceRecord)
+        assertTrue(hasNoComplexTypes(transformedRecord))
+    }
+
     private val sourceSchema = AvroSchema.fromJson(fileContent("com/cultureamp/employee-data.employees-value-v1.avsc"))
 
     private fun payload(fileName: String): SchemaAndValue {

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
@@ -126,6 +126,23 @@ class RedShiftComplexDataTypeTransformerTest {
         assertTrue(hasNoComplexTypes(transformedRecord))
     }
 
+    @Test
+    fun `can transform ECST Employee data with tombstone message and null key and null value schema`() {
+        val sourceRecord = SourceRecord(
+            null,
+            null,
+            "employee data ecst test",
+            null,
+            null,
+            null,
+            null,
+            null
+        )
+
+        val transformedRecord = transformer.apply(sourceRecord)
+        assertTrue(hasNoComplexTypes(transformedRecord))
+    }
+
     private val sourceSchema = AvroSchema.fromJson(fileContent("com/cultureamp/employee-data.employees-value-v1.avsc"))
 
     private fun payload(fileName: String): SchemaAndValue {


### PR DESCRIPTION
- Currently [RedShiftComplexDataTypeTransformer.kt](https://github.com/cultureamp/kafka-connect-plugins/pull/16/files#diff-1c6b1f1e25e59f4c6c0a8ad03ced685d77497c526cc72f54805dfca22da64987) is unable to handle tombstone messages. This PR implements the functionality to handle tombstones by:
- The transformer is able to handle `null` topic `value`
- If keySchema is available, the transformer is able to add a column `topic_key` and populate it with the topic key 
- A column `tombstone` is added (with default value `false`) and is set to `true` if the `value` is `null`
- Added unit tests with combinations of `null` and non-null `key` and `value`
- Tested with https://github.com/cultureamp/kafka-ops/pull/863, Jira Ticket: https://cultureamp.atlassian.net/browse/DPT-375

```
select *
from incoming."employee-data_imports_v1"
where tombstone = true 
limit 100;
```
<img width="1166" alt="image" src="https://github.com/cultureamp/kafka-connect-plugins/assets/123911715/75ad99e0-6ec6-4f20-bdb0-6246303dfeca">

```
select *
from incoming."employee-data_imports_v1"
where tombstone = false 
limit 100;
```
<img width="1147" alt="image" src="https://github.com/cultureamp/kafka-connect-plugins/assets/123911715/605dd72c-ec87-42f4-95b6-ef18da4b867d">
