### PR TITLE
Redshift Transformer Bug: Set default value 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("org.jmailen.kotlinter") version "3.6.0"
 
     // Vulnerable dependency checker
-    id("org.owasp.dependencycheck") version "9.0.2"
+    id("org.owasp.dependencycheck") version "9.0.8"
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 // Package version
-version = "0.7.5"
+version = "0.7.6-alpha"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 // Package version
-version = "0.7.6-alpha"
+version = "0.7.6"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
@@ -8,9 +8,9 @@ import com.mongodb.kafka.connect.util.ClassHelper
 import com.mongodb.kafka.connect.util.ConfigHelper
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaAndValue
+import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.source.SourceRecord
-import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.transforms.util.SchemaUtil
 import org.junit.Before
 import java.io.File
@@ -368,7 +368,6 @@ class RedShiftComplexDataTypeTransformerTest {
         }
         return builder.build()
     }
-
 
     private val jsonWriterSettings =
         ClassHelper.createInstance(

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
@@ -10,6 +10,8 @@ import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaAndValue
 import org.apache.kafka.connect.data.Struct
 import org.apache.kafka.connect.source.SourceRecord
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.transforms.util.SchemaUtil
 import org.junit.Before
 import java.io.File
 import java.nio.file.Files
@@ -74,7 +76,7 @@ class RedShiftComplexDataTypeTransformerTest {
         )
 
         assertEquals(expectedValue, transformedRecord.value())
-        assertEquals(expectedSchema, transformedRecord.valueSchema())
+        assertEquals(getExpectedSchema(), transformedRecord.valueSchema())
     }
 
     @Test
@@ -94,13 +96,13 @@ class RedShiftComplexDataTypeTransformerTest {
         assertTrue(hasNoComplexTypes(transformedRecord))
 
         val expectedValue = nullBodyStruct(
-            id, account_id, employee_id, event_created_at, metadata_correlation_id, metadata_causation_id, metadata_executor_id, metadata_service, test_array_of_structs, test_string_array, test_array_of_arrays, test_map,
+            id, account_id, employee_id, event_created_at, metadata_correlation_id, metadata_causation_id, metadata_executor_id, "Default-Service", test_array_of_structs, test_string_array, test_array_of_arrays, test_map,
             topic_key = "",
             tombstone = true
         )
 
         assertEquals(expectedValue, transformedRecord.value())
-        assertEquals(expectedSchema, transformedRecord.valueSchema())
+        assertEquals(getExpectedSchema(), transformedRecord.valueSchema())
     }
 
     @Test
@@ -129,7 +131,7 @@ class RedShiftComplexDataTypeTransformerTest {
         )
 
         assertEquals(expectedValue, transformedRecord.value())
-        assertEquals(expectedSchema, transformedRecord.valueSchema())
+        assertEquals(getExpectedSchema(), transformedRecord.valueSchema())
     }
 
     @Test
@@ -171,10 +173,10 @@ class RedShiftComplexDataTypeTransformerTest {
         hasNoComplexTypes(sourceRecord)
         assertTrue(hasNoComplexTypes(transformedRecord))
 
-        val expectedValue = Struct(expectedSchema).put("tombstone", true)
+        val expectedValue = Struct(getExpectedSchema()).put("tombstone", true)
 
         assertEquals(expectedValue, transformedRecord.value())
-        assertEquals(expectedSchema, transformedRecord.valueSchema())
+        assertEquals(getExpectedSchema(), transformedRecord.valueSchema())
     }
 
     @Test
@@ -266,7 +268,7 @@ class RedShiftComplexDataTypeTransformerTest {
         topic_key: String?,
         tombstone: Boolean
     ): Struct {
-        val returnStruct = Struct(expectedSchema)
+        val returnStruct = Struct(getExpectedSchema())
         returnStruct.put("id", id)
             .put("account_id", account_id)
             .put("employee_id", employee_id)
@@ -318,7 +320,7 @@ class RedShiftComplexDataTypeTransformerTest {
         topic_key: String?,
         tombstone: Boolean
     ): Struct {
-        val returnStruct = Struct(expectedSchema)
+        val returnStruct = Struct(getExpectedSchema())
         returnStruct.put("id", id)
             .put("account_id", account_id)
             .put("employee_id", employee_id)
@@ -344,7 +346,29 @@ class RedShiftComplexDataTypeTransformerTest {
         return String(Files.readAllBytes(File(url.file).toPath()))
     }
 
-    private val expectedSchema = AvroSchema.fromJson(fileContent("com/cultureamp/employee-data.employees-v1-target-schema.avsc"))
+    private fun convertFieldSchema(orig: Schema, optional: Boolean, defaultFromParent: Any?): Schema {
+        val builder = SchemaUtil.copySchemaBasics(orig)
+        if (optional)
+            builder.optional()
+        if (defaultFromParent != null)
+            builder.defaultValue(defaultFromParent)
+        return builder.build()
+    }
+
+    private fun getExpectedSchema(): Schema {
+        val expectedSchema = AvroSchema.fromJson(fileContent("com/cultureamp/employee-data.employees-v1-target-schema.avsc"))
+        val builder = SchemaUtil.copySchemaBasics(expectedSchema)
+        for (field in expectedSchema.fields()) {
+            if (field.name() == "body_observer")
+                builder.field("body_observer", convertFieldSchema(SchemaBuilder.bool().build(), true, true))
+            else if (field.name() == "metadata_service")
+                builder.field("metadata_service", convertFieldSchema(SchemaBuilder.string().build(), true, "Default-Service"))
+            else
+                builder.field(field.name(), field.schema())
+        }
+        return builder.build()
+    }
+
 
     private val jsonWriterSettings =
         ClassHelper.createInstance(

--- a/src/test/resources/com/cultureamp/employee-data.employees-v1-target-schema.avsc
+++ b/src/test/resources/com/cultureamp/employee-data.employees-v1-target-schema.avsc
@@ -86,10 +86,10 @@
           {
             "name": "body_observer",
             "type": [
-              "null",
-              "boolean"
+              "boolean",
+              "null"
             ],
-            "default": null
+            "default": true
           },
           {
             "name": "body_gdpr_erasure_request_id",
@@ -213,10 +213,10 @@
       {
         "name": "metadata_service",
         "type": [
-              "null",
-              "string"
+              "string",
+              "null"
             ],
-            "default": null
+        "default": "Default-Service"
       },
     {
       "name": "test_array_of_structs",

--- a/src/test/resources/com/cultureamp/employee-data.employees-v2.json
+++ b/src/test/resources/com/cultureamp/employee-data.employees-v2.json
@@ -11,8 +11,7 @@
 		"causation_id": null,
 		"executor_id": {
 			"string": "379907ca-632c-4e83-89c4-9dbe0e759ad3"
-		},
-		"service": "Influx"
+		}
 	},
 	"test_array_of_structs": [
 		{

--- a/src/test/resources/com/cultureamp/employee-data.employees-value-v1.avsc
+++ b/src/test/resources/com/cultureamp/employee-data.employees-value-v1.avsc
@@ -89,11 +89,8 @@
           },
           {
             "name": "observer",
-            "type": [
-              "null",
-              "boolean"
-            ],
-            "default": null
+            "type": "boolean",
+            "default": true
           },
           {
             "name": "gdpr_erasure_request_id",
@@ -259,7 +256,8 @@
           },
           {
             "name": "service",
-            "type": "string"
+            "type": "string",
+            "default": "Default-Service"
           }
         ]
       }


### PR DESCRIPTION
## Context
Redshift Transformer bug 
``` 
Caused by: java.lang.ClassCastException: class java.lang.String cannot be cast to class org.apache.kafka.connect.data.Struct (java.lang.String is in module java.base of loader 'bootstrap'; org.apache.kafka.connect.data.Struct is in unnamed module of loader 'app')
	at com.cultureamp.kafka.connect.plugins.transforms.RedShiftComplexDataTypeTransformer.buildUpdatedSchema(RedShiftComplexDataTypeTransformer.kt:89)
	at com.cultureamp.kafka.connect.plugins.transforms.RedShiftComplexDataTypeTransformer.targetPayload(RedShiftComplexDataTypeTransformer.kt:177)
	at com.cultureamp.kafka.connect.plugins.transforms.RedShiftComplexDataTypeTransformer.apply(RedShiftComplexDataTypeTransformer.kt:46)
	at org.apache.kafka.connect.runtime.TransformationChain.lambda$apply$0(TransformationChain.java:50)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndRetry(RetryWithToleranceOperator.java:180)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:214)
	... 15 more
```
caused by force-casting non-null default values to `STRUCT`

## Implementation
- Remove force-casting non-null default values to `STRUCT`
- Set the value to Default Value if the value is `null`
- Update Unit tests to confirm the change works
- Updated `org.owasp.dependencycheck` to version "9.0.8" due to breaking [build](https://github.com/cultureamp/kafka-connect-plugins/actions/runs/7456510101/job/20287270405), related Slack thread [here](https://cultureamp.slack.com/archives/C02BYR1N188/p1704773913515039)
- Update package version to `0.7.6`

## Testing
- Tested with a connector in https://github.com/cultureamp/kafka-ops/pull/1097/files



