### PR TITLE
Bug Fix Redshift Transformer default values for Array and Maps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 // Package version
-version = "0.7.8-alpha"
+version = "0.7.8"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-val kafkaVersion = "3.6.0"
+val kafkaVersion = "3.6.2"
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
@@ -31,6 +31,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
     // Kafka dependencies
+    // Previous 3.6.0 version was flagged as vulnerability:
+    // CVE-2024-27309 https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEKAFKA-6600922
     implementation("org.apache.kafka:connect-api:$kafkaVersion")
     implementation("org.apache.kafka:connect-json:$kafkaVersion")
     implementation("org.apache.kafka:connect-transforms:$kafkaVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 // Package version
-version = "0.7.7"
+version = "0.7.8-alpha"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
@@ -71,13 +71,13 @@ class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<
         }
     }
 
-    private fun convertFieldSchema(orig: Schema, optional: Boolean, defaultFromParent: Any?): Schema {
+    private fun convertFieldSchema(orig: Schema, optional: Boolean, defaultFromParent: Any?, complexType: Boolean = false): Schema {
         // Note that we don't use the schema translation cache here. It might save us a bit of effort, but we really
         // only care about caching top-level schema translations.
         val builder = SchemaUtil.copySchemaBasics(orig)
         if (optional)
             builder.optional()
-        if (defaultFromParent != null)
+        if (defaultFromParent != null && !complexType)
             builder.defaultValue(defaultFromParent)
         return builder.build()
     }
@@ -103,8 +103,8 @@ class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<
                 Schema.Type.BOOLEAN -> newSchema.field(fieldName, convertFieldSchema(field.schema(), optional, fieldDefaultValue))
                 Schema.Type.STRING -> newSchema.field(fieldName, convertFieldSchema(field.schema(), optional, fieldDefaultValue))
                 Schema.Type.BYTES -> newSchema.field(fieldName, convertFieldSchema(field.schema(), optional, fieldDefaultValue))
-                Schema.Type.ARRAY -> newSchema.field(fieldName, convertFieldSchema(SchemaBuilder.string().build(), optional, fieldDefaultValue))
-                Schema.Type.MAP -> newSchema.field(fieldName, convertFieldSchema(SchemaBuilder.string().build(), optional, fieldDefaultValue))
+                Schema.Type.ARRAY -> newSchema.field(fieldName, convertFieldSchema(SchemaBuilder.string().build(), optional, fieldDefaultValue, true))
+                Schema.Type.MAP -> newSchema.field(fieldName, convertFieldSchema(SchemaBuilder.string().build(), optional, fieldDefaultValue, true))
                 Schema.Type.STRUCT -> buildUpdatedSchema(field.schema(), fieldName, newSchema, optional)
                 else -> throw DataException(
                     "Flatten transformation does not support " + field.schema().type() +


### PR DESCRIPTION
- Current Redshift Transformer serializes `ARRAY` and `MAP` types to `STRING`. Hence, it should not pass the default value from the input schema to the output schema. This PR fixes the bug throwing the following error: 
<img width="1161" alt="image" src="https://github.com/cultureamp/kafka-connect-plugins/assets/123911715/9e674ad2-bf90-4409-8b87-e84db0c552eb">

- Unit tests haven't been updated due to the test suite library `org.mongodb.kafka:mongo-kafka-connect` to read AVRO schema can't handle default values for `ARRAY` or `MAP` types. This has been tested with `kafka-ops` [PR](https://github.com/cultureamp/kafka-ops/pull/1536) branch instead.
- Updating `kafkaVersion` due to vulnerability CVE-2024-27309 https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEKAFKA-6600922