### PR TITLE
RedShiftComplexDataTypeTransformer - Added Kafka Metadata fields

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 // Package version
-version = "0.7.9-alpha"
+version = "0.7.9"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 // Package version
-version = "0.7.8"
+version = "0.7.9-alpha"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/src/test/resources/com/cultureamp/employee-data.employees-v1-target-schema.avsc
+++ b/src/test/resources/com/cultureamp/employee-data.employees-v1-target-schema.avsc
@@ -259,6 +259,30 @@
       "name": "tombstone",
       "type": "boolean",
       "default": false
+    },
+    {
+      "name": "_kafka_metadata_partition",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "_kafka_metadata_offset",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "_kafka_metadata_timestamp",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     }
   ]
 }


### PR DESCRIPTION
## Context
https://cultureamp.atlassian.net/browse/TDPR-126

## Implementation
- Adding Kafka metadata fields `_kafka_metadata_partition`, `_kafka_metadata_offset ` and `_kafka_metadata_timestamp` to map to `record.kafkaPartition()`, `record.kafkaOffset()`, `record.timestamp()` respectively. 
- Version upgrade in `build.gradle.kts`

## Testing
- Updated unit tests: `src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt` and schema `src/test/resources/com/cultureamp/employee-data.employees-v1-target-schema.avsc`
- Testing with `kafka-ops` Data Lake Connectors: https://github.com/cultureamp/kafka-ops/pull/1571, columns created and populated as per screenshot
<img width="1625" alt="image" src="https://github.com/cultureamp/kafka-connect-plugins/assets/123911715/e037d689-ff61-4794-85c4-6905b8ff1897">


