### PR TITLE
Small fixes to ModifyPartition plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Assume the following configuration:
 
 ```json
 "transforms": "ModifyPartition",
-"transforms.ModifyPartition.type":"com.cultureamp.kafka.connect.transforms.ModifyPartition",
+"transforms.ModifyPartition.type":"com.cultureamp.kafka.connect.plugins.transforms.ModifyPartition",
 "transforms.ModifyPartition.header.key": "account_id"
 "transforms.ModifyPartition.number.partitions": "10"
 ```

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/ModifyPartition.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/ModifyPartition.kt
@@ -33,7 +33,7 @@ class ModifyPartition<R : ConnectRecord<R>> : Transformation<R> {
         } else if (partitionCount!! <= 0) {
             throw ConnectException("Partition count should be greater than 0")
         }
-        val userSpecifiedPartitionKey = record.headers().lastWithName(headerKey).value() as String?
+        val userSpecifiedPartitionKey = record.headers().lastWithName(headerKey)?.value() as String?
 
         if (userSpecifiedPartitionKey != null) {
             val partitionNumber = Partitioner(CRC32(), partitionCount!!).partitionNumberFor(userSpecifiedPartitionKey)

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/ModifyPartitionTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/ModifyPartitionTest.kt
@@ -27,6 +27,27 @@ class ModifyPartitionTest {
     }
 
     @Test
+    fun `a missing header key should not result in a null pointer exception, but a connect exception`() {
+        val partitionSmt = configure("header.key" to "account_id", "number.partitions" to 10)
+        val record = SourceRecord(
+            null,
+            null,
+            "test",
+            0,
+            null,
+            null,
+            null,
+            "",
+            789L,
+            headers()
+        )
+
+        assertFailsWith<ConnectException> {
+            partitionSmt.apply(record)
+        }
+    }
+
+    @Test
     fun `calculate the partition number using the account_id header`() {
         val partitionSmt = configure("header.key" to "account_id", "number.partitions" to 10)
         val record = SourceRecord(


### PR DESCRIPTION
While POCing this plugin to implement a custom partitioning strategy, I noticed a couple of opportunities:

- `README` had an error in the connect configuration it provides
- There is a null pointer exception that is thrown if the routing-relevant header is missing. Looking at the code this appears unintentional since there is a null check further down which throws a connector error if the field is missing. Fixed the code to make it null safe and covered with test.