### PR TITLE
DPT-1978: Transformer to convert JSON to hex string so that it can be loaded into varbyte column

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,61 @@ Assume the following configuration:
 
 Target Avro Schema: `resources/com/cultureamp/slack-integration-target-schema.avsc`
 
+## JsonToHexTransformer
+
+Converts schemaless JSON objects to hexadecimal format for storage in Redshift varbyte columns. This transformer takes the complete JSON payload (including nested fields) and converts it to a single hexadecimal string, making it suitable for Redshift varbyte columns which can handle up to 5MB of data.
+
+### Use Case
+When you have JSON data with nested structures that need to be stored in Redshift but don't want to flatten or lose the original structure, this transformer allows you to store the complete JSON as a hex-encoded string in a varbyte column. This is particularly useful for:
+- Complex nested JSON structures
+- JSON data that might have schema variations
+- Preserving complete JSON payloads for later processing
+
+### Configuration properties
+
+|Name|Description|Type|Default|Importance|
+|---|---|---|---|---|
+|`hex.field.name`|Name of the field to store the hex-encoded JSON payload|string|`json_hex`|MEDIUM|
+
+### Examples
+
+Assume the following configuration:
+
+```json
+"transforms": "JsonToHex",
+"transforms.JsonToHex.type": "com.cultureamp.kafka.connect.plugins.transforms.JsonToHexTransformer",
+"transforms.JsonToHex.hex.field.name": "json_payload_hex"
+```
+
+Example transformation:
+
+**Before:**
+```json
+{
+  "user": {
+    "name": "John Doe",
+    "details": {
+      "age": 30,
+      "city": "New York",
+      "preferences": ["coding", "reading"]
+    }
+  },
+  "metadata": {
+    "timestamp": "2023-01-01T00:00:00Z",
+    "version": 1
+  }
+}
+```
+
+**After:**
+```json
+{
+  "json_payload_hex": "7b2275736572223a7b226e616d65223a224a6f686e20446f65222c2264657461696c73223a7b22616765223a33302c2263697479223a224e657720596f726b222c22707265666572656e636573223a5b22636f64696e67222c227265616"
+}
+```
+
+The hex string can then be stored in a Redshift varbyte column and decoded back to the original JSON when needed.
+
 ## Installation
 This library is built as a single `.jar` and published as a Github release. To install in your Connect cluster, add the JAR file to a directory that is on the clusters `plugin.path`.
 

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/JsonToHexTransformer.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/JsonToHexTransformer.kt
@@ -1,0 +1,129 @@
+package com.cultureamp.kafka.connect.plugins.transforms
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.connect.connector.ConnectRecord
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.sink.SinkRecord
+import org.apache.kafka.connect.transforms.Transformation
+import org.apache.kafka.connect.transforms.util.SchemaUtil
+import org.slf4j.LoggerFactory
+import java.nio.charset.StandardCharsets
+
+/**
+ * A Kafka Connect transformer that converts schemaless JSON objects to hexadecimal format
+ * for Redshift varbyte columns.
+ *
+ * This transformer takes the complete JSON payload and converts it to a single hexadecimal
+ * string suitable for storage in Redshift varbyte columns. It handles schemaless JSON data
+ * with nested structures up to 5MB in size.
+ *
+ * Features:
+ * - Converts entire JSON object to a single hex string
+ * - Handles schemaless JSON with nested structures
+ * - Simple and lightweight transformation
+ * - Configurable output field name
+ *
+ * Configuration:
+ * - hex.field.name: Name of the field to store the hex-encoded JSON (default: "json_hex")
+ *
+ * @param R is ConnectRecord<R>.
+ */
+class JsonToHexTransformer<R : ConnectRecord<R>> : Transformation<R> {
+
+    companion object {
+        const val CONFIG_HEX_FIELD_NAME = "hex.field.name"
+        private const val HEX_FIELD_NAME_DEFAULT = "json_hex"
+    }
+
+    private val logger = LoggerFactory.getLogger(this::class.java.canonicalName)
+    private val objectMapper = ObjectMapper()
+    private var hexFieldName: String = HEX_FIELD_NAME_DEFAULT
+
+    override fun configure(configs: MutableMap<String, *>?) {
+        hexFieldName = configs?.get(CONFIG_HEX_FIELD_NAME) as? String ?: HEX_FIELD_NAME_DEFAULT
+        logger.info("Configured JsonToHexTransformer - hexFieldName: $hexFieldName")
+    }
+
+    override fun config(): ConfigDef {
+        return ConfigDef()
+            .define(
+                CONFIG_HEX_FIELD_NAME,
+                ConfigDef.Type.STRING,
+                HEX_FIELD_NAME_DEFAULT,
+                ConfigDef.Importance.MEDIUM,
+                "Name of the field to store the hex-encoded JSON payload"
+            )
+    }
+
+    override fun close() {}
+
+    override fun apply(record: R): R {
+        try {
+            return transformRecord(record)
+        } catch (e: Exception) {
+            logger.error("Exception processing record: ", e)
+            logger.error("Record received: ${record.value()}")
+            throw e
+        }
+    }
+
+    /**
+     * Converts a string to hexadecimal representation
+     */
+    private fun stringToHex(input: String): String {
+        return input.toByteArray(StandardCharsets.UTF_8)
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private fun convertFieldSchema(orig: Schema, optional: Boolean, defaultValue: Any?): Schema {
+        val builder = SchemaUtil.copySchemaBasics(orig)
+        if (optional)
+            builder.optional()
+        if (defaultValue != null)
+            builder.defaultValue(defaultValue)
+        return builder.build()
+    }
+
+    private fun transformRecord(record: R): R {
+        val value = record.value()
+
+        // Convert the value to JSON string
+        val jsonString = when (value) {
+            is String -> value
+            is Map<*, *> -> objectMapper.writeValueAsString(value)
+            else -> objectMapper.writeValueAsString(value)
+        }
+
+        // Convert JSON string to hex
+        val hexValue = stringToHex(jsonString)
+
+        // Create new schema with hex field and Kafka metadata fields
+        val newSchema = SchemaBuilder.struct()
+            .name("HexEncodedJson")
+            .field(hexFieldName, Schema.STRING_SCHEMA)
+            .field("_kafka_metadata_partition", convertFieldSchema(SchemaBuilder.int32().build(), false, null))
+            .field("_kafka_metadata_offset", convertFieldSchema(SchemaBuilder.int64().build(), false, null))
+            .field("_kafka_metadata_timestamp", convertFieldSchema(SchemaBuilder.int64().build(), false, null))
+            .build()
+
+        // Create new struct with values
+        val newValue = Struct(newSchema)
+            .put(hexFieldName, hexValue)
+            .put("_kafka_metadata_partition", record.kafkaPartition())
+            .put("_kafka_metadata_offset", (record as SinkRecord).kafkaOffset())
+            .put("_kafka_metadata_timestamp", record.timestamp())
+
+        return record.newRecord(
+            record.topic(),
+            record.kafkaPartition(),
+            record.keySchema(),
+            record.key(),
+            newSchema,
+            newValue,
+            record.timestamp()
+        ) as R
+    }
+}

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/JsonToHexTransformerKafkaMetadataTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/JsonToHexTransformerKafkaMetadataTest.kt
@@ -1,0 +1,131 @@
+package com.cultureamp.kafka.connect.plugins.transforms
+
+import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.connect.sink.SinkRecord
+import org.junit.Before
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Test for JsonToHexTransformer with Kafka metadata fields (always enabled)
+ */
+class JsonToHexTransformerKafkaMetadataTest {
+
+    private lateinit var transformer: JsonToHexTransformer<SinkRecord>
+
+    @Before
+    fun setUp() {
+        transformer = JsonToHexTransformer()
+        transformer.configure(
+            mutableMapOf<String, Any>(
+                "hex.field.name" to "payload_hex"
+            )
+        )
+    }
+
+    @Test
+    fun `should always include Kafka metadata fields`() {
+        val testJson = mapOf("test" to "data", "nested" to mapOf("field" to "value"))
+
+        val record = SinkRecord(
+            "test-topic",
+            2,
+            null,
+            null,
+            null,
+            testJson,
+            156L,
+            1713922160000L,
+            TimestampType.CREATE_TIME
+        )
+
+        val result = transformer.apply(record)
+
+        // Verify schema has all expected fields
+        assertNotNull(result.valueSchema())
+        assertEquals("HexEncodedJson", result.valueSchema().name())
+        assertEquals(4, result.valueSchema().fields().size) // payload_hex + 3 metadata fields
+
+        val resultStruct = result.value() as org.apache.kafka.connect.data.Struct
+
+        // Verify hex payload is present
+        assertNotNull(resultStruct.get("payload_hex"))
+
+        // Verify Kafka metadata fields are present
+        assertEquals(2, resultStruct.get("_kafka_metadata_partition"))
+        assertEquals(156L, resultStruct.get("_kafka_metadata_offset"))
+        assertEquals(1713922160000L, resultStruct.get("_kafka_metadata_timestamp"))
+
+        println("✅ Transformer always includes all expected fields:")
+        println("   - payload_hex: ${(resultStruct.get("payload_hex") as String).take(20)}...")
+        println("   - _kafka_metadata_partition: ${resultStruct.get("_kafka_metadata_partition")}")
+        println("   - _kafka_metadata_offset: ${resultStruct.get("_kafka_metadata_offset")}")
+        println("   - _kafka_metadata_timestamp: ${resultStruct.get("_kafka_metadata_timestamp")}")
+    }
+
+    @Test
+    fun `should handle OpenTelemetry data with Kafka metadata`() {
+        val otelData = mapOf(
+            "resourceSpans" to listOf(
+                mapOf(
+                    "resource" to mapOf(
+                        "attributes" to listOf(
+                            mapOf("key" to "service.name", "value" to mapOf("stringValue" to "ai-coach-api"))
+                        )
+                    ),
+                    "scopeSpans" to listOf(
+                        mapOf(
+                            "scope" to mapOf("name" to "openinference.instrumentation.agno"),
+                            "spans" to listOf(
+                                mapOf(
+                                    "traceId" to "0f60f165cd4491691af2d5bc36f1037b",
+                                    "spanId" to "23ae78014c176545",
+                                    "name" to "search_knowledge_base",
+                                    "attributes" to listOf(
+                                        mapOf("key" to "session_id", "value" to mapOf("stringValue" to "test-session"))
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val record = SinkRecord(
+            "opentelemetry-spans",
+            0,
+            null,
+            null,
+            null,
+            otelData,
+            999L,
+            System.currentTimeMillis(),
+            TimestampType.CREATE_TIME
+        )
+
+        val result = transformer.apply(record)
+        val resultStruct = result.value() as org.apache.kafka.connect.data.Struct
+
+        // Verify all fields are present
+        assertNotNull(resultStruct.get("payload_hex"))
+        assertEquals(0, resultStruct.get("_kafka_metadata_partition"))
+        assertEquals(999L, resultStruct.get("_kafka_metadata_offset"))
+        assertNotNull(resultStruct.get("_kafka_metadata_timestamp"))
+
+        // Verify hex contains the OpenTelemetry data
+        val hexValue = resultStruct.get("payload_hex") as String
+        val originalBytes = hexValue.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        val reconstructedJson = String(originalBytes, Charsets.UTF_8)
+
+        assert(reconstructedJson.contains("ai-coach-api"))
+        assert(reconstructedJson.contains("search_knowledge_base"))
+        assert(reconstructedJson.contains("0f60f165cd4491691af2d5bc36f1037b"))
+
+        println("✅ OpenTelemetry data with metadata processed successfully!")
+        println("   - Hex length: ${hexValue.length}")
+        println("   - Partition: ${resultStruct.get("_kafka_metadata_partition")}")
+        println("   - Offset: ${resultStruct.get("_kafka_metadata_offset")}")
+    }
+}

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/JsonToHexTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/JsonToHexTransformerTest.kt
@@ -1,0 +1,254 @@
+package com.cultureamp.kafka.connect.plugins.transforms
+
+import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.sink.SinkRecord
+import org.junit.Before
+import java.nio.charset.StandardCharsets
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Unit tests for JsonToHexTransformer
+ */
+class JsonToHexTransformerTest {
+
+    private lateinit var transformer: JsonToHexTransformer<SinkRecord>
+
+    @Before
+    fun setUp() {
+        transformer = JsonToHexTransformer()
+        transformer.configure(mutableMapOf<String, Any>())
+    }
+
+    @Test
+    fun `should convert simple JSON string to hex`() {
+        val jsonString = """{"name":"John","age":30}"""
+        val expectedHex = stringToHex(jsonString)
+
+        val record = SinkRecord(
+            "test-topic",
+            0,
+            null,
+            null,
+            null,
+            jsonString,
+            0L,
+            System.currentTimeMillis(),
+            TimestampType.CREATE_TIME
+        )
+
+        val result = transformer.apply(record)
+
+        assertNotNull(result.valueSchema())
+        assertEquals("HexEncodedJson", result.valueSchema().name())
+        assertEquals(Schema.Type.STRUCT, result.valueSchema().type())
+
+        val resultStruct = result.value() as org.apache.kafka.connect.data.Struct
+        assertEquals(expectedHex, resultStruct.get("json_hex"))
+    }
+
+    @Test
+    fun `should convert nested JSON object to hex`() {
+        val nestedJson = mapOf(
+            "user" to mapOf(
+                "name" to "John Doe",
+                "details" to mapOf(
+                    "age" to 30,
+                    "city" to "New York",
+                    "preferences" to listOf("coding", "reading")
+                )
+            ),
+            "metadata" to mapOf(
+                "timestamp" to "2023-01-01T00:00:00Z",
+                "version" to 1
+            )
+        )
+
+        val record = SinkRecord(
+            "test-topic",
+            0,
+            null,
+            null,
+            null,
+            nestedJson,
+            0L,
+            System.currentTimeMillis(),
+            TimestampType.CREATE_TIME
+        )
+
+        val result = transformer.apply(record)
+
+        assertNotNull(result.valueSchema())
+        val resultStruct = result.value() as org.apache.kafka.connect.data.Struct
+        val hexValue = resultStruct.get("json_hex") as String
+
+        // Verify it's valid hex (even length, only hex chars)
+        assertEquals(0, hexValue.length % 2)
+        assert(hexValue.matches(Regex("[0-9a-f]+")))
+
+        // Verify we can convert back to original JSON structure
+        val originalBytes = hexValue.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        val reconstructedJson = String(originalBytes, StandardCharsets.UTF_8)
+        assert(reconstructedJson.contains("John Doe"))
+        assert(reconstructedJson.contains("New York"))
+        assert(reconstructedJson.contains("coding"))
+    }
+
+    @Test
+    fun `should handle empty JSON object`() {
+        val emptyJson = "{}"
+        val expectedHex = stringToHex(emptyJson)
+
+        val record = SinkRecord(
+            "test-topic",
+            0,
+            null,
+            null,
+            null,
+            emptyJson,
+            0L,
+            System.currentTimeMillis(),
+            TimestampType.CREATE_TIME
+        )
+
+        val result = transformer.apply(record)
+        val resultStruct = result.value() as org.apache.kafka.connect.data.Struct
+        assertEquals(expectedHex, resultStruct.get("json_hex"))
+    }
+
+    @Test
+    fun `should handle JSON array`() {
+        val jsonArray = listOf(
+            mapOf("id" to 1, "name" to "Item 1"),
+            mapOf("id" to 2, "name" to "Item 2")
+        )
+
+        val record = SinkRecord(
+            "test-topic",
+            0,
+            null,
+            null,
+            null,
+            jsonArray,
+            0L,
+            System.currentTimeMillis(),
+            TimestampType.CREATE_TIME
+        )
+
+        val result = transformer.apply(record)
+        val resultStruct = result.value() as org.apache.kafka.connect.data.Struct
+        val hexValue = resultStruct.get("json_hex") as String
+
+        // Verify it's valid hex
+        assertEquals(0, hexValue.length % 2)
+        assert(hexValue.matches(Regex("[0-9a-f]+")))
+    }
+
+    @Test
+    fun `should handle large JSON payload`() {
+        // Create a larger JSON object
+        val largeData = mutableMapOf<String, Any>()
+        repeat(1000) { i ->
+            largeData["field_$i"] = "This is a longer string value for field $i with some additional content to make it bigger"
+        }
+        largeData["nested"] = mapOf(
+            "level1" to mapOf(
+                "level2" to mapOf(
+                    "level3" to "deep nested value"
+                )
+            )
+        )
+
+        val record = SinkRecord(
+            "test-topic",
+            0,
+            null,
+            null,
+            null,
+            largeData,
+            0L,
+            System.currentTimeMillis(),
+            TimestampType.CREATE_TIME
+        )
+
+        val result = transformer.apply(record)
+        val resultStruct = result.value() as org.apache.kafka.connect.data.Struct
+        val hexValue = resultStruct.get("json_hex") as String
+
+        // Verify it's valid hex and reasonably large
+        assertEquals(0, hexValue.length % 2)
+        assert(hexValue.matches(Regex("[0-9a-f]+")))
+        assert(hexValue.length > 1000) // Should be quite large
+    }
+
+    @Test
+    fun `should use custom field name when configured`() {
+        val customTransformer = JsonToHexTransformer<SinkRecord>()
+        customTransformer.configure(mutableMapOf<String, Any>("hex.field.name" to "custom_hex_field"))
+
+        val jsonString = """{"test":"value"}"""
+        val expectedHex = stringToHex(jsonString)
+
+        val record = SinkRecord(
+            "test-topic",
+            0,
+            null,
+            null,
+            null,
+            jsonString,
+            0L,
+            System.currentTimeMillis(),
+            TimestampType.CREATE_TIME
+        )
+
+        val result = customTransformer.apply(record)
+        val resultStruct = result.value() as org.apache.kafka.connect.data.Struct
+        assertEquals(expectedHex, resultStruct.get("custom_hex_field"))
+    }
+
+    @Test
+    fun `should handle special characters and unicode`() {
+        val jsonWithSpecialChars = mapOf(
+            "emoji" to "🚀",
+            "special" to "Special chars: àáâãäåæçèéêë",
+            "quotes" to "Text with \"quotes\" and 'apostrophes'",
+            "newlines" to "Line 1\nLine 2\tTabbed"
+        )
+
+        val record = SinkRecord(
+            "test-topic",
+            0,
+            null,
+            null,
+            null,
+            jsonWithSpecialChars,
+            0L,
+            System.currentTimeMillis(),
+            TimestampType.CREATE_TIME
+        )
+
+        val result = transformer.apply(record)
+        val resultStruct = result.value() as org.apache.kafka.connect.data.Struct
+        val hexValue = resultStruct.get("json_hex") as String
+
+        // Verify it's valid hex
+        assertEquals(0, hexValue.length % 2)
+        assert(hexValue.matches(Regex("[0-9a-f]+")))
+
+        // Verify we can reconstruct and it contains our special characters
+        val originalBytes = hexValue.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        val reconstructedJson = String(originalBytes, StandardCharsets.UTF_8)
+        assert(reconstructedJson.contains("🚀"))
+        assert(reconstructedJson.contains("àáâãäåæçèéêë"))
+    }
+
+    /**
+     * Helper function to convert string to hex for testing
+     */
+    private fun stringToHex(input: String): String {
+        return input.toByteArray(StandardCharsets.UTF_8)
+            .joinToString("") { "%02x".format(it) }
+    }
+}


### PR DESCRIPTION
### Context
JIRA: https://cultureamp.atlassian.net/browse/DPT-1978
Solution Preview: https://cultureamp.atlassian.net/wiki/x/3IEgaQE

This PR was developed using :claude: . Has been tested locally.

### Testing:
Conducted end-to-end test. The plugin was built locally and mounted in a docker volume for `localStack`. AWS credentials were provided to the connector, and it successfully wrote a hex-encoded payload to S3 as a JSON file. The data was then successfully loaded into a VARBYTE column.

#### Output file from S3:
[dolly.local-connector-s3-redshift.s3-redshift-sink.v1(000000000000_000000000002) (1).json](https://github.com/user-attachments/files/26198121/dolly.local-connector-s3-redshift.s3-redshift-sink.v1.000000000000_000000000002.1.json)
<img width="1728" height="502" alt="Screenshot 2026-03-24 at 11 59 47 am" src="https://github.com/user-attachments/assets/c219afc4-bc09-494a-9f0f-3995f20a8a29" />

#### Redshift Copy command:
```
COPY "datalake"."incoming"."test_s3_sink_tbl" (json_payload, _kafka_metadata_partition, _kafka_metadata_offset, _kafka_metadata_timestamp)
FROM 's3://data-lake-otel-staging-515671630768-us-west-2/dolly/s3-redshift-sink/year=2026/month=03/day=24/'
IAM_ROLE 'arn:aws:iam::515671630768:role/data-lake-redshift-ingestion-cluster-service-role'
JSON 's3://data-lake-otel-staging-515671630768-us-west-2/jsonpaths.txt'
REGION 'us-west-2';
```

#### Redshift results:
The record with offset 2 was the one that was loaded
<img width="1068" height="529" alt="Screenshot 2026-03-24 at 12 00 48 pm" src="https://github.com/user-attachments/assets/0099ec73-f129-44e5-8fb1-b27179d33ba0" />
