### PR TITLE
feat: add SoftDeleteToTombstoneTransformer for hard-deleting soft-deleted ECST records

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,40 @@ Example transformation:
 
 The hex string can then be stored in a Redshift varbyte column and decoded back to the original JSON when needed.
 
+## SoftDeleteToTombstoneTransformer
+
+Converts soft-deleted records into tombstones (null value) so that the JDBC Sink Connector issues a DELETE instead of an upsert. When a record's soft-delete field (e.g. `body.deleted_at`) is non-null, the transformer replaces the record value with null while preserving the key, enabling hard deletes downstream.
+
+### Configuration properties
+
+|Name|Description|Type|Default|Importance|
+|---|---|---|---|---|
+|`field`|Dot-notation path to the soft-delete field|string|`body.deleted_at`|HIGH|
+
+### Examples
+
+Assume the following configuration:
+
+```yaml
+transforms: "SoftDeleteToTombstone"
+transforms.SoftDeleteToTombstone.type: "com.cultureamp.kafka.connect.plugins.transforms.SoftDeleteToTombstoneTransformer"
+transforms.SoftDeleteToTombstone.field: "body.deleted_at"
+```
+
+**Before (soft-deleted record):**
+```json
+Key: {"id": "abc-123"}
+Value: {"body": {"deleted_at": 1700000000000, "name": "Test"}, "metadata": "..."}
+```
+
+**After (tombstone):**
+```json
+Key: {"id": "abc-123"}
+Value: null
+```
+
+Non-deleted records (where `body.deleted_at` is null) pass through unchanged.
+
 ## Installation
 This library is built as a single `.jar` and published as a Github release. To install in your Connect cluster, add the JAR file to a directory that is on the clusters `plugin.path`.
 

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/SoftDeleteToTombstoneTransformer.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/SoftDeleteToTombstoneTransformer.kt
@@ -1,0 +1,60 @@
+package com.cultureamp.kafka.connect.plugins.transforms
+
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.common.config.ConfigDef.Importance.HIGH
+import org.apache.kafka.connect.connector.ConnectRecord
+import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.transforms.Transformation
+import org.apache.kafka.connect.transforms.util.SimpleConfig
+import org.slf4j.LoggerFactory
+
+class SoftDeleteToTombstoneTransformer<R : ConnectRecord<R>> : Transformation<R> {
+    private lateinit var fieldPath: List<String>
+
+    companion object {
+        const val FIELD_CONFIG = "field"
+        const val FIELD_DEFAULT = "body.deleted_at"
+        val CONFIG_DEF: ConfigDef = ConfigDef()
+            .define(FIELD_CONFIG, ConfigDef.Type.STRING, FIELD_DEFAULT, HIGH, "Dot-notation path to the soft-delete field.")
+        private val logger = LoggerFactory.getLogger(SoftDeleteToTombstoneTransformer::class.java)
+    }
+
+    override fun configure(configs: MutableMap<String, *>?) {
+        val config = SimpleConfig(CONFIG_DEF, configs)
+        fieldPath = config.getString(FIELD_CONFIG).split(".")
+    }
+
+    override fun close() {}
+
+    override fun apply(record: R): R {
+        if (record.value() == null) {
+            return record
+        }
+
+        val value = record.value()
+        if (value !is Struct) {
+            logger.warn("Record value is not a Struct, passing through unchanged. Topic: {}", record.topic())
+            return record
+        }
+
+        val deletedAtValue = resolveFieldValue(value)
+        return if (deletedAtValue != null) {
+            logger.debug("Soft-deleted record detected, converting to tombstone. Topic: {}, Key: {}", record.topic(), record.key())
+            record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), null, null, record.timestamp())
+        } else {
+            record
+        }
+    }
+
+    private fun resolveFieldValue(struct: Struct): Any? {
+        var current: Struct = struct
+        for (i in 0 until fieldPath.size - 1) {
+            current = current.getStruct(fieldPath[i]) ?: return null
+        }
+        return current.get(fieldPath.last())
+    }
+
+    override fun config(): ConfigDef {
+        return CONFIG_DEF
+    }
+}

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/SoftDeleteToTombstoneTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/SoftDeleteToTombstoneTransformerTest.kt
@@ -1,0 +1,168 @@
+package com.cultureamp.kafka.connect.plugins.transforms
+
+import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.sink.SinkRecord
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class SoftDeleteToTombstoneTransformerTest {
+
+    private fun configure(vararg props: Pair<String, Any>): SoftDeleteToTombstoneTransformer<SinkRecord> {
+        val transformProperties = mutableMapOf<String, Any>()
+        for (prop in props) {
+            transformProperties[prop.first] = prop.second
+        }
+        val smt = SoftDeleteToTombstoneTransformer<SinkRecord>()
+        smt.configure(transformProperties)
+        return smt
+    }
+
+    private val bodySchema: Schema = SchemaBuilder.struct()
+        .field("deleted_at", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .build()
+
+    private val valueSchema: Schema = SchemaBuilder.struct()
+        .field("body", bodySchema)
+        .field("metadata", Schema.OPTIONAL_STRING_SCHEMA)
+        .build()
+
+    private val keySchema: Schema = SchemaBuilder.struct()
+        .field("id", Schema.STRING_SCHEMA)
+        .build()
+
+    private fun sinkRecord(
+        value: Struct?,
+        key: Struct? = Struct(keySchema).put("id", "abc-123"),
+        timestamp: Long = 12345L,
+    ): SinkRecord {
+        return SinkRecord(
+            "test-topic",
+            0,
+            keySchema,
+            key,
+            valueSchema,
+            value,
+            0L,
+            timestamp,
+            TimestampType.CREATE_TIME,
+        )
+    }
+
+    @Test
+    fun `soft deleted record is converted to tombstone`() {
+        val smt = configure()
+        val body = Struct(bodySchema).put("deleted_at", 1700000000000L).put("name", "Test")
+        val value = Struct(valueSchema).put("body", body).put("metadata", "some-meta")
+        val key = Struct(keySchema).put("id", "abc-123")
+        val record = sinkRecord(value, key)
+
+        val result = smt.apply(record)
+
+        assertNull(result.value(), "Tombstone record should have null value")
+        assertNull(result.valueSchema(), "Tombstone record should have null value schema")
+        assertNotNull(result.key(), "Key must be preserved for JDBC sink DELETE")
+        assertEquals("abc-123", (result.key() as Struct).get("id"))
+        assertEquals("test-topic", result.topic())
+        assertEquals(12345L, result.timestamp())
+    }
+
+    @Test
+    fun `normal record passes through unchanged`() {
+        val smt = configure()
+        val body = Struct(bodySchema).put("deleted_at", null).put("name", "Test")
+        val value = Struct(valueSchema).put("body", body).put("metadata", "some-meta")
+        val record = sinkRecord(value)
+
+        val result = smt.apply(record)
+
+        assertNotNull(result.value(), "Non-deleted record should pass through")
+        assertEquals(value, result.value())
+    }
+
+    @Test
+    fun `existing tombstone passes through unchanged`() {
+        val smt = configure()
+        val record = sinkRecord(null)
+
+        val result = smt.apply(record)
+
+        assertNull(result.value(), "Tombstone should remain a tombstone")
+    }
+
+    @Test
+    fun `custom field path works correctly`() {
+        val metadataSchema = SchemaBuilder.struct()
+            .field("removed_at", Schema.OPTIONAL_STRING_SCHEMA)
+            .build()
+        val customSchema = SchemaBuilder.struct()
+            .field("metadata", metadataSchema)
+            .build()
+
+        val smt = configure("field" to "metadata.removed_at")
+        val metadata = Struct(metadataSchema).put("removed_at", "2024-01-01T00:00:00Z")
+        val value = Struct(customSchema).put("metadata", metadata)
+        val key = Struct(keySchema).put("id", "def-456")
+        val record = SinkRecord("custom-topic", 0, keySchema, key, customSchema, value, 0L, 99L, TimestampType.CREATE_TIME)
+
+        val result = smt.apply(record)
+
+        assertNull(result.value(), "Record with custom soft-delete field set should become tombstone")
+        assertEquals("def-456", (result.key() as Struct).get("id"))
+    }
+
+    @Test
+    fun `single level field path works`() {
+        val flatSchema = SchemaBuilder.struct()
+            .field("deleted_at", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .build()
+
+        val smt = configure("field" to "deleted_at")
+        val value = Struct(flatSchema).put("deleted_at", 1700000000000L).put("name", "Test")
+        val key = Struct(keySchema).put("id", "ghi-789")
+        val record = SinkRecord("flat-topic", 0, keySchema, key, flatSchema, value, 0L, 50L, TimestampType.CREATE_TIME)
+
+        val result = smt.apply(record)
+
+        assertNull(result.value(), "Record with top-level deleted_at set should become tombstone")
+    }
+
+    @Test
+    fun `null intermediate struct passes through unchanged`() {
+        val outerSchema = SchemaBuilder.struct()
+            .field("body", SchemaBuilder.struct().field("deleted_at", Schema.OPTIONAL_INT64_SCHEMA).optional().build())
+            .build()
+
+        val smt = configure()
+        val value = Struct(outerSchema).put("body", null)
+        val record = SinkRecord("test-topic", 0, keySchema, Struct(keySchema).put("id", "abc"), outerSchema, value, 0L, 100L, TimestampType.CREATE_TIME)
+
+        val result = smt.apply(record)
+
+        assertNotNull(result.value(), "Record with null intermediate struct should pass through")
+    }
+
+    @Test
+    fun `key and topic are preserved in tombstone`() {
+        val smt = configure()
+        val body = Struct(bodySchema).put("deleted_at", 1700000000000L)
+        val value = Struct(valueSchema).put("body", body)
+        val key = Struct(keySchema).put("id", "preserve-me")
+        val record = SinkRecord("important-topic", 3, keySchema, key, valueSchema, value, 0L, 99999L, TimestampType.CREATE_TIME)
+
+        val result = smt.apply(record)
+
+        assertNull(result.value())
+        assertEquals("important-topic", result.topic())
+        assertEquals(3, result.kafkaPartition())
+        assertEquals(keySchema, result.keySchema())
+        assertEquals("preserve-me", (result.key() as Struct).get("id"))
+        assertEquals(99999L, result.timestamp())
+    }
+}


### PR DESCRIPTION
## Purpose
When we delete something in ECST, the deleted row sticks around in the database instead of actually being removed. This PR adds a transformer that fixes that by telling the database to properly delete the row.

## Context
Right now, when an ECST entity gets deleted, a message is published with a `deleted_at` timestamp filled in — but the database connector just treats it as an update, so the row stays. Every query then needs a `WHERE deleted_at IS NULL` filter to hide these ghost rows.

This new transformer (`SoftDeleteToTombstoneTransformer`) watches for that `deleted_at` field. When it's set, it converts the message into a "tombstone" (a message with no value but still has the key), which the database connector understands as "delete this row". Works out of the box for `role_assignments`, `surveys`, and `survey_to_questions` connectors.

[ERS-5187](https://cultureamp.atlassian.net/browse/ERS-5187)

## Verification
- [x] 7 unit tests passing — covers the main scenarios like converting deletes to tombstones, leaving normal records alone, handling missing fields, and making sure the record key is preserved so the database knows which row to delete
- [x] No lint issues
- [ ] Deploy to staging and confirm rows actually get removed when `deleted_at` is set

[ERS-5187]: https://cultureamp.atlassian.net/browse/ERS-5187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ