### PR TITLE
feat: add UnquoteRecordKey transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,35 @@ Value: null
 
 Non-deleted records (where `body.deleted_at` is null) pass through unchanged.
 
+## UnquoteRecordKey
+
+Strips surrounding double quotes from string record keys. Some ECST topics store keys as JSON-encoded strings (e.g. `"37d8c6b0-..."` with extra quotes). This causes issues with JDBC Sink Connectors where the key is used as a primary key — the extra quotes result in invalid UUID syntax in PostgreSQL.
+
+This transform removes the surrounding quotes so the key is a clean value (e.g. `37d8c6b0-...`).
+
+### Configuration properties
+
+No configuration required.
+
+### Examples
+
+```yaml
+transforms: "StripKeyQuotes"
+transforms.StripKeyQuotes.type: "com.cultureamp.kafka.connect.plugins.transforms.UnquoteRecordKey"
+```
+
+**Before:**
+```
+Key: "\"37d8c6b0-941f-41bc-a50a-9559dd9cabf1\""
+```
+
+**After:**
+```
+Key: "37d8c6b0-941f-41bc-a50a-9559dd9cabf1"
+```
+
+Keys without surrounding quotes pass through unchanged.
+
 ## Installation
 This library is built as a single `.jar` and published as a Github release. To install in your Connect cluster, add the JAR file to a directory that is on the clusters `plugin.path`.
 

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnquoteRecordKey.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnquoteRecordKey.kt
@@ -1,0 +1,43 @@
+package com.cultureamp.kafka.connect.plugins.transforms
+
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.connect.connector.ConnectRecord
+import org.apache.kafka.connect.transforms.Transformation
+import org.slf4j.LoggerFactory
+
+class UnquoteRecordKey<R : ConnectRecord<R>> : Transformation<R> {
+
+    companion object {
+        val CONFIG_DEF: ConfigDef = ConfigDef()
+        private val logger = LoggerFactory.getLogger(UnquoteRecordKey::class.java)
+    }
+
+    override fun configure(configs: MutableMap<String, *>?) {}
+
+    override fun close() {}
+
+    override fun apply(record: R): R {
+        val key = record.key()
+        if (key == null || key !is String) {
+            return record
+        }
+
+        val stripped = key.removeSurrounding("\"")
+        if (stripped == key) {
+            return record
+        }
+
+        logger.debug("Stripped surrounding quotes from key. Topic: {}, Original: {}, Stripped: {}", record.topic(), key, stripped)
+        return record.newRecord(
+            record.topic(),
+            record.kafkaPartition(),
+            record.keySchema(),
+            stripped,
+            record.valueSchema(),
+            record.value(),
+            record.timestamp(),
+        )
+    }
+
+    override fun config(): ConfigDef = CONFIG_DEF
+}

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnquoteRecordKeyTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/UnquoteRecordKeyTest.kt
@@ -1,0 +1,128 @@
+package com.cultureamp.kafka.connect.plugins.transforms
+
+import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.sink.SinkRecord
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class UnquoteRecordKeyTest {
+
+    private fun createSmt(): UnquoteRecordKey<SinkRecord> {
+        val smt = UnquoteRecordKey<SinkRecord>()
+        smt.configure(mutableMapOf<String, Any>())
+        return smt
+    }
+
+    private val valueSchema: Schema = SchemaBuilder.struct()
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .build()
+
+    private fun sinkRecord(
+        key: Any?,
+        value: Struct? = Struct(valueSchema).put("name", "test"),
+        timestamp: Long = 12345L,
+    ): SinkRecord {
+        return SinkRecord(
+            "test-topic",
+            0,
+            Schema.OPTIONAL_STRING_SCHEMA,
+            key,
+            valueSchema,
+            value,
+            0L,
+            timestamp,
+            TimestampType.CREATE_TIME,
+        )
+    }
+
+    @Test
+    fun `strips surrounding quotes from key`() {
+        val smt = createSmt()
+        val record = sinkRecord("\"37d8c6b0-941f-41bc-a50a-9559dd9cabf1\"")
+
+        val result = smt.apply(record)
+
+        assertEquals("37d8c6b0-941f-41bc-a50a-9559dd9cabf1", result.key())
+        assertEquals("test-topic", result.topic())
+        assertEquals(12345L, result.timestamp())
+    }
+
+    @Test
+    fun `key without quotes passes through unchanged`() {
+        val smt = createSmt()
+        val record = sinkRecord("37d8c6b0-941f-41bc-a50a-9559dd9cabf1")
+
+        val result = smt.apply(record)
+
+        assertEquals("37d8c6b0-941f-41bc-a50a-9559dd9cabf1", result.key())
+    }
+
+    @Test
+    fun `null key passes through unchanged`() {
+        val smt = createSmt()
+        val record = sinkRecord(null)
+
+        val result = smt.apply(record)
+
+        assertNull(result.key())
+    }
+
+    @Test
+    fun `non-string key passes through unchanged`() {
+        val smt = createSmt()
+        val keySchema = SchemaBuilder.struct().field("id", Schema.STRING_SCHEMA).build()
+        val key = Struct(keySchema).put("id", "abc-123")
+        val record = SinkRecord(
+            "test-topic", 0, keySchema, key, valueSchema,
+            Struct(valueSchema).put("name", "test"), 0L, 12345L, TimestampType.CREATE_TIME,
+        )
+
+        val result = smt.apply(record)
+
+        assertEquals(key, result.key())
+    }
+
+    @Test
+    fun `key with only one quote is not stripped`() {
+        val smt = createSmt()
+        val record = sinkRecord("\"37d8c6b0-941f-41bc-a50a-9559dd9cabf1")
+
+        val result = smt.apply(record)
+
+        assertEquals("\"37d8c6b0-941f-41bc-a50a-9559dd9cabf1", result.key())
+    }
+
+    @Test
+    fun `value is preserved after stripping key`() {
+        val smt = createSmt()
+        val value = Struct(valueSchema).put("name", "important-data")
+        val record = sinkRecord("\"some-key\"", value)
+
+        val result = smt.apply(record)
+
+        assertEquals("some-key", result.key())
+        assertNotNull(result.value())
+        assertEquals("important-data", (result.value() as Struct).get("name"))
+    }
+
+    @Test
+    fun `partition and topic are preserved`() {
+        val smt = createSmt()
+        val record = SinkRecord(
+            "my-topic", 5, Schema.OPTIONAL_STRING_SCHEMA, "\"quoted-key\"",
+            valueSchema, Struct(valueSchema).put("name", "test"), 0L, 99999L, TimestampType.CREATE_TIME,
+        )
+
+        val result = smt.apply(record)
+
+        assertEquals("quoted-key", result.key())
+        assertEquals("my-topic", result.topic())
+        assertEquals(5, result.kafkaPartition())
+        assertEquals(99999L, result.timestamp())
+    }
+}


### PR DESCRIPTION
## Purpose
Add a new SMT that strips surrounding double quotes from string record keys so they can be used as primary keys in JDBC Sink Connectors.

## Context
ECST topic keys are stored as JSON-encoded strings with extra surrounding quotes (e.g. `"37d8c6b0-..."` instead of `37d8c6b0-...`). When using `pk.mode: record_key` with the JDBC Sink Connector, the extra quotes cause PostgreSQL to reject the value with `invalid input syntax for type uuid`. This is the same issue the multi-source-signals Kotlin consumer will handle with `key.removeSurrounding("\"")`.

[ERS-5116](https://cultureamp.atlassian.net/browse/ERS-5116)

## Verification
- [x] Unit tests pass (7 test cases)
- [x] Lint passes
- [ ] Build and release new version

[ERS-5116]: https://cultureamp.atlassian.net/browse/ERS-5116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ