### PR TITLE
fix: JSON Converter configuration lifecycle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 // Package version
-version = "0.9.0"
+version = "0.9.1"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 // Package version
-version = "0.9.1"
+version = "0.12.1"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
+++ b/src/main/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformer.kt
@@ -34,7 +34,9 @@ class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<
     private val purpose = "RedShift™ Flatten and Complex Data Types to String Transform"
     private val schemaUpdateCache = SynchronizedCache<Schema, Schema>(LRUCache<Schema, Schema>(16))
 
-    override fun configure(configs: MutableMap<String, *>?) {}
+    override fun configure(configs: MutableMap<String, *>?) {
+        jsonConverter.configure(Collections.singletonMap("schemas.enable", false), true)
+    }
 
     override fun config(): ConfigDef {
         return ConfigDef()
@@ -178,8 +180,6 @@ class RedShiftComplexDataTypeTransformer<R : ConnectRecord<R>> : Transformation<
         val sourceValue = Requirements.requireStructOrNull(record.value(), purpose)
         val sourceSchema = record.valueSchema()
         var updatedSchema = schemaUpdateCache.get(sourceSchema)
-        val props = Collections.singletonMap("schemas.enable", false)
-        jsonConverter.configure(props, true)
         if (updatedSchema == null) {
             var builder: SchemaBuilder = SchemaUtil.copySchemaBasics(SchemaBuilder.struct())
             if (sourceSchema != null) {

--- a/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
+++ b/src/test/kotlin/com/cultureamp/kafka/connect/plugins/transforms/RedShiftComplexDataTypeTransformerTest.kt
@@ -52,6 +52,7 @@ class RedShiftComplexDataTypeTransformerTest {
     @Before
     fun setUp() {
         transformer = RedShiftComplexDataTypeTransformer()
+        transformer.configure(mutableMapOf<String, Any?>())
     }
 
     @Test


### PR DESCRIPTION
# Context

JsonConverter configuration was occurring for every record received in the SMT pipeline.

This has now moved to the configure() block, so JsonConverter is now only configured at the start of the task lifecycle -- reducing the frequency of `INFO` logs to ECS